### PR TITLE
Fix compile error if DTFoundation.h not in precompiled header

### DIFF
--- a/Core/Source/NSString+DTFormatNumbers.m
+++ b/Core/Source/NSString+DTFormatNumbers.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSString+DTFormatNumbers.h"
+#import "LoadableCategory.h"
 
 // force this category to be loaded by linker
 MAKE_CATEGORIES_LOADABLE(NSString_DTFormatNumbers);

--- a/Core/Source/NSURL+DTAppLinks.m
+++ b/Core/Source/NSURL+DTAppLinks.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSURL+DTAppLinks.h"
+#import "LoadableCategory.h"
 
 // force this category to be loaded by linker
 MAKE_CATEGORIES_LOADABLE(NSURL_DTAppLinks);

--- a/Core/Source/NSURL+DTPrefLinks.m
+++ b/Core/Source/NSURL+DTPrefLinks.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSURL+DTPrefLinks.h"
+#import "LoadableCategory.h"
 
 // force this category to be loaded by linker
 MAKE_CATEGORIES_LOADABLE(NSURL_DTPrefLinks);

--- a/Core/Source/UIView+DTFoundation.m
+++ b/Core/Source/UIView+DTFoundation.m
@@ -8,6 +8,7 @@
 
 #import "UIView+DTFoundation.h"
 #import <QuartzCore/QuartzCore.h>
+#import "LoadableCategory.h"
 
 // force this category to be loaded by linker
 MAKE_CATEGORIES_LOADABLE(UIView_DTFoundation);


### PR DESCRIPTION
Several files will not compile if DTFoundation.h is not in the pch file.  Fix adds the missing header files to the code.
