### PR TITLE
Fix for extra dot (.) when calling pathByIncrementingSequenceNumber

### DIFF
--- a/Core/Source/NSString+DTPaths.m
+++ b/Core/Source/NSString+DTPaths.m
@@ -84,6 +84,10 @@ MAKE_CATEGORIES_LOADABLE(NSString_DTPaths);
 	
 	NSString *nakedName = [baseName pathByDeletingSequenceNumber];
 	
+	if ([extension isEqualToString:@""]) {
+		return [nakedName stringByAppendingFormat:@"(%d)", sequenceNumber+1];
+	}
+	
 	return [[nakedName stringByAppendingFormat:@"(%d)", sequenceNumber+1] stringByAppendingPathExtension:extension];
 }
 


### PR DESCRIPTION
Added extra check for empty extensions before returning.
