### PR TITLE
Comparing dispatch_get_current_queue and dispatch_get_main_queue is explicitly forbidden by the documentation

### DIFF
--- a/Core/Source/iOS/UIView+DTDebug.m
+++ b/Core/Source/iOS/UIView+DTDebug.m
@@ -11,7 +11,7 @@
 
 @implementation UIView (DTDebug)
 
-- (BOOL)isMainThread
+- (BOOL)_isMainThread
 {
     return [NSThread mainThread];
 }
@@ -23,7 +23,7 @@
 
 - (void)_setNeedsLayout_MainQueueCheck
 {
-    if (![self isMainThread])
+    if (![self _isMainThread])
     {
         [self methodCalledNotFromMainQueue:NSStringFromSelector(_cmd)];
     }
@@ -34,7 +34,7 @@
 
 - (void)_setNeedsDisplay_MainQueueCheck
 {
-    if (![self isMainThread])
+    if (![self _isMainThread])
     {
         [self methodCalledNotFromMainQueue:NSStringFromSelector(_cmd)];
     }
@@ -45,7 +45,7 @@
 
 - (void)_setNeedsDisplayInRect_MainQueueCheck:(CGRect)rect
 {
-    if (![self isMainThread])
+    if (![self _isMainThread])
     {
         [self methodCalledNotFromMainQueue:NSStringFromSelector(_cmd)];
     }


### PR DESCRIPTION
Checking the right way if a method is invoked from the main thread. The GCD documentation states: (`dispatch/queue.h`)

> When dispatch_get_current_queue() is called on the main thread, it may
> or may not return the same value as dispatch_get_main_queue(). Comparing
> the two is not a valid way to test whether code is executing on the
> main thread.
