### PR TITLE
Remove pragma compiler warning

### DIFF
--- a/Core/Source/iOS/DTActionSheet.m
+++ b/Core/Source/iOS/DTActionSheet.m
@@ -90,7 +90,7 @@
 	return retIndex;
 }
 
-#pragma UIActionSheetDelegate (forwarded)
+#pragma mark UIActionSheetDelegate (forwarded)
 
 - (void)actionSheetCancel:(UIActionSheet *)actionSheet
 {


### PR DESCRIPTION
With the warning level our project is using, the compiler complains about this malformed pragma mark. Mind pulling in a fix so our next pod won't generate that warning? Thanks!
![screen shot 2013-06-28 at 1 30 15 pm](https://f.cloud.github.com/assets/1934212/724367/45bf51a8-e032-11e2-8947-ddd7103c73e2.png)
