### PR TITLE
Add the ! to the OS_OBJECT_USE_OBJC if check in DTFolderMonitor

### DIFF
--- a/Core/Source/DTFolderMonitor.m
+++ b/Core/Source/DTFolderMonitor.m
@@ -54,7 +54,7 @@
 {
 	[self stopMonitoring];
 	
-#if OS_OBJECT_USE_OBJC
+#if !OS_OBJECT_USE_OBJC
 	dispatch_release(_queue);
 #endif
 }


### PR DESCRIPTION
Prevents an error when compiling for iOS 6.0+.

Fixes issue raised in https://github.com/Cocoanetics/DTCoreText/issues/689
