### PR TITLE
Fixed HEADER_SEARCH_PATCHS in podspec

### DIFF
--- a/DTFoundation.podspec
+++ b/DTFoundation.podspec
@@ -52,7 +52,7 @@ Pod::Spec.new do |spec|
     ss.dependency 'DTFoundation/Core'
     ss.source_files = 'Core/Source/DTHTMLParser/*.{h,m}'
     ss.library = 'xml2'
-    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(SDKROOT)/usr/include/libxml2"' }
   end
 
   spec.subspec 'DTReachability' do |ss|


### PR DESCRIPTION
HEADER_SEARCH_PATHS without quotes are not working if Xcode is installed in a path which has spaces in in.
e.g. /Applications/Xcode 4.6.3.app
