### PR TITLE
Fixed warning: weak property '_delegate' is accessed multiple times in t...

### DIFF
--- a/Core/Source/DTHTMLParser/DTHTMLParser.m
+++ b/Core/Source/DTHTMLParser/DTHTMLParser.m
@@ -318,9 +318,10 @@ void _processingInstruction (void *context, const xmlChar *target, const xmlChar
 	_handler.processingInstruction = NULL;
 	
 	// inform delegate
-	if ([_delegate respondsToSelector:@selector(parser:parseErrorOccurred:)])
+	__strong __typeof__(_delegate) delegate = _delegate;
+	if ([delegate respondsToSelector:@selector(parser:parseErrorOccurred:)])
 	{
-		[_delegate parser:self parseErrorOccurred:self.parserError];
+		[delegate parser:self parseErrorOccurred:self.parserError];
 	}
 }
 
@@ -335,7 +336,7 @@ void _processingInstruction (void *context, const xmlChar *target, const xmlChar
 {
 	_delegate = delegate;
 	
-	if ([_delegate respondsToSelector:@selector(parserDidStartDocument:)])
+	if ([delegate respondsToSelector:@selector(parserDidStartDocument:)])
 	{
 		_handler.startDocument = _startDocument;
 	}
@@ -344,7 +345,7 @@ void _processingInstruction (void *context, const xmlChar *target, const xmlChar
 		_handler.startDocument = NULL;
 	}
 	
-	if ([_delegate respondsToSelector:@selector(parserDidEndDocument:)])
+	if ([delegate respondsToSelector:@selector(parserDidEndDocument:)])
 	{
 		_handler.endDocument = _endDocument;
 	}


### PR DESCRIPTION
...his block but may be unpredictably set to nil; assign to a strong variable to keep the object alive [-Warc-repeated-use-of-weak]
