### PR TITLE
Changed designated initializer, so it will work with iOS 8

### DIFF
--- a/Core/Source/iOS/BlocksAdditions/DTAlertView.m
+++ b/Core/Source/iOS/BlocksAdditions/DTAlertView.m
@@ -46,7 +46,14 @@
 // designated initializer
 - (id)initWithTitle:(NSString *)title message:(NSString *)message
 {
-	return [self initWithTitle:title message:message delegate:nil cancelButtonTitle:nil otherButtonTitles:nil];
+	self = [self init];
+	if (self)
+	{
+		self.title = title;
+        	self.message = message;
+	}
+
+	return self;
 }
 
 - (NSInteger)addButtonWithTitle:(NSString *)title block:(DTAlertViewBlock)block


### PR DESCRIPTION
In iOS 8, DTAlertView dit not work anymore. 

The overridden standard init method was not called anymore, so the _actionsPerIndex remained nil and blocks were not executed anymore.

I tested this change on iOS 8 beta4, iOS 7.1 and iOS 6.
