### PR TITLE
Crash on didPresentActionSheet: and willPresentActionsheet:

### DIFF
--- a/Core/Source/iOS/BlocksAdditions/DTActionSheet.m
+++ b/Core/Source/iOS/BlocksAdditions/DTActionSheet.m
@@ -121,7 +121,7 @@
 
 - (void)willPresentActionSheet:(UIActionSheet *)actionSheet
 {
-	if ([self.actionSheetDelegate respondsToSelector:@selector(actionSheet:willDismissWithButtonIndex:)])
+    if ([self.actionSheetDelegate respondsToSelector:@selector(willPresentActionSheet:)])
 	{
 		[self.actionSheetDelegate willPresentActionSheet:actionSheet];
 	}
@@ -129,7 +129,7 @@
 
 - (void)didPresentActionSheet:(UIActionSheet *)actionSheet
 {
-	if ([self.actionSheetDelegate respondsToSelector:@selector(actionSheet:didDismissWithButtonIndex:)])
+    if ([self.actionSheetDelegate respondsToSelector:@selector(didPresentActionSheet:)])
 	{
 		[self.actionSheetDelegate didPresentActionSheet:actionSheet];
 	}


### PR DESCRIPTION
In these two methods the respondsToSelector call was checking for the incorrect method being implemented on the actionSheetDelegate.
