### PR TITLE
Framework not compiling with latest CocoaPods 1.0 beta

### DIFF
--- a/Core/Source/DTASN1/DTASN1Parser.h
+++ b/Core/Source/DTASN1/DTASN1Parser.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 /**
  Types of ASN1 tags, specifying the type of the following value in TLV notation

--- a/Core/Source/DTASN1/DTASN1Parser.m
+++ b/Core/Source/DTASN1/DTASN1Parser.m
@@ -8,7 +8,7 @@
 
 #import "DTASN1Parser.h"
 #import "DTASN1BitString.h"
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 #import "DTLog.h"
 
 @implementation DTASN1Parser

--- a/Core/Source/DTHTMLParser/DTHTMLParser.h
+++ b/Core/Source/DTHTMLParser/DTHTMLParser.h
@@ -7,7 +7,7 @@
 //
 
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 @class DTHTMLParser;
 /** The DTHTMLParserDelegate protocol defines the optional methods implemented by delegates of DTHTMLParser objects. 

--- a/Core/Source/iOS/BlocksAdditions/DTActionSheet.h
+++ b/Core/Source/iOS/BlocksAdditions/DTActionSheet.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 #import <Availability.h>
 
 // the block to execute when an option button is tapped

--- a/Core/Source/iOS/BlocksAdditions/DTActionSheet.m
+++ b/Core/Source/iOS/BlocksAdditions/DTActionSheet.m
@@ -7,7 +7,7 @@
 //
 
 #import "DTActionSheet.h"
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 #import "DTLog.h"
 

--- a/Core/Source/iOS/BlocksAdditions/DTAlertView.h
+++ b/Core/Source/iOS/BlocksAdditions/DTAlertView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 #import <Availability.h>
 
 #if !TARGET_OS_TV && __IPHONE_OS_VERSION_MIN_REQUIRED < 80000

--- a/Core/Source/iOS/DTSidePanel/DTSidePanelController.h
+++ b/Core/Source/iOS/DTSidePanel/DTSidePanelController.h
@@ -7,8 +7,8 @@
 //
 
 #import "UIViewController+DTSidePanelController.h"
-#import "DTWeakSupport.h"
-#import "DTCompatibility.h"
+#import <DTFoundation/DTWeakSupport.h>
+#import <DTFoundation/DTCompatibility.h>
 
 
 

--- a/Core/Source/iOS/DTSidePanel/DTSidePanelControllerSegue.h
+++ b/Core/Source/iOS/DTSidePanel/DTSidePanelControllerSegue.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 @class DTSidePanelController;
 

--- a/Core/Source/iOS/DTSmartPagingScrollView.h
+++ b/Core/Source/iOS/DTSmartPagingScrollView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 @class DTSmartPagingScrollView;
 


### PR DESCRIPTION
The project is not compiling with the latest CocoaPods beta version, as a dynamic framework, I got the following error:

![screen shot 2016-02-26 at 09 30 55](https://cloud.githubusercontent.com/assets/346590/13347969/076c651a-dc71-11e5-9909-638d1ec079cb.png)

Which I can fix by changing all `DTWeakSupport` and `DTCompatibility` import statements in the project to modular imports: `#import <DTFoundation/...>` but that doesn't look right to me, they're exported in the umbrella header either way: https://github.com/Cocoanetics/DTFoundation/blob/develop/Core/DTFoundation.h#L27

Do you have any idea why this is not working? This happens on a beta version of CocoaPods either way, so maybe it's a bug on CocoaPods but I'm opening this PR to gather some information before filling an issue there.