### PR TITLE
Use framework references

### DIFF
--- a/Core/Source/DTHTMLParser/DTHTMLParser.h
+++ b/Core/Source/DTHTMLParser/DTHTMLParser.h
@@ -7,7 +7,7 @@
 //
 
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 @class DTHTMLParser;
 /** The DTHTMLParserDelegate protocol defines the optional methods implemented by delegates of DTHTMLParser objects. 

--- a/Core/Source/iOS/DTSmartPagingScrollView.h
+++ b/Core/Source/iOS/DTSmartPagingScrollView.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Cocoanetics. All rights reserved.
 //
 
-#import "DTWeakSupport.h"
+#import <DTFoundation/DTWeakSupport.h>
 
 @class DTSmartPagingScrollView;
 


### PR DESCRIPTION
When included as a pod using CocoaPods with the `use_frameworks!` directive the file references don't work correctly and throw build errors. You have to reference relative to the framework. These are the cases that I encountered using DTCoreText.