### PR TITLE
Replaces the unavailable 'objc_unretainedPointer' in Xcode 8

### DIFF
--- a/Core/Source/Runtime/NSObject+DTRuntime.m
+++ b/Core/Source/Runtime/NSObject+DTRuntime.m
@@ -48,7 +48,7 @@ static char DTRuntimeDeallocBlocks;
 #if MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_7
     void *impBlockForIMP = (void *)objc_unretainedPointer(block);
 #else
-    id impBlockForIMP = (__bridge id)objc_unretainedPointer(block);
+    id impBlockForIMP = (__bridge id)(__bridge void *)(block);
 #endif
     
     IMP myIMP = imp_implementationWithBlock(impBlockForIMP);


### PR DESCRIPTION
Replaces the unavailable 'objc_unretainedPointer' in Xcode 8 with a __bridge cast to resolve build error.