### PR TITLE
Remove incorrect TARGETED_DEVICE_FAMILY for tvOS

### DIFF
--- a/DTFoundation.xcodeproj/project.pbxproj
+++ b/DTFoundation.xcodeproj/project.pbxproj
@@ -3984,7 +3984,6 @@
 				PRODUCT_NAME = DTFoundation;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -4018,7 +4017,6 @@
 				PRODUCT_NAME = DTFoundation;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -4051,7 +4049,6 @@
 				PRODUCT_NAME = DTFoundation;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
This incorrect TARGETED_DEVICE_FAMILY was causing the tvOS version of the framework to not build with Carthage.