### PR TITLE
Add SPM support with swift package init

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "DTFoundation",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "DTFoundation",
+            targets: ["DTFoundation"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "DTFoundation",
+            dependencies: []),
+        .testTarget(
+            name: "DTFoundationTests",
+            dependencies: ["DTFoundation"]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# DTFoundation
+
+A description of this package.

--- a/Sources/DTFoundation/DTFoundation.swift
+++ b/Sources/DTFoundation/DTFoundation.swift
@@ -1,0 +1,3 @@
+struct DTFoundation {
+    var text = "Hello, World!"
+}

--- a/Tests/DTFoundationTests/DTFoundationTests.swift
+++ b/Tests/DTFoundationTests/DTFoundationTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import DTFoundation
+
+final class DTFoundationTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(DTFoundation().text, "Hello, World!")
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Tests/DTFoundationTests/XCTestManifests.swift
+++ b/Tests/DTFoundationTests/XCTestManifests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+#if !canImport(ObjectiveC)
+public func allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(DTFoundationTests.allTests),
+    ]
+}
+#endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import DTFoundationTests
+
+var tests = [XCTestCaseEntry]()
+tests += DTFoundationTests.allTests()
+XCTMain(tests)


### PR DESCRIPTION
Add support for SPM to DTFoundation. This appears to work correctly via Add Package Dependency in Xcode (on the spm branch) but I haven't tested in detail.